### PR TITLE
Minor fixes

### DIFF
--- a/test.fsx
+++ b/test.fsx
@@ -1,5 +1,13 @@
 module Test2
 
+let rec sum v m s =
+    if v >= m
+    then s
+    else sum (v + 1L) m (s + v)
+
+printfn "sum 0 10000L 0 -> %d" (sum 0L 10000L 0L)
+printfn "(must be equal to 49995000)"
+
 let rec factorial aux n =
   if n = 0 then aux
   else factorial (aux * n) (n - 1)

--- a/test.js
+++ b/test.js
@@ -3,6 +3,7 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
+exports.sum = sum;
 exports.factorial = factorial;
 exports.parseNum_parseTokens = parseNum_parseTokens;
 exports.parseNum = parseNum;
@@ -10,13 +11,39 @@ exports.parseTokens = parseTokens;
 
 var _fableCore = require("fable-core");
 
+function sum(v, m, s) {
+  _letrec: while (true) {
+    if (v >= m) {
+      return s;
+    } else {
+      var $tmp0 = v + 1;
+      var $tmp1 = m;
+      var $tmp2 = s + v;
+      v = $tmp0;
+      m = $tmp1;
+      s = $tmp2;
+      continue _letrec;
+    }
+  }
+}
+
+_fableCore.String.fsFormat("sum 0 10000L 0 -> %d")(function (x) {
+  console.log(x);
+})(sum(0, 10000, 0));
+
+_fableCore.String.fsFormat("(must be equal to 49995000)")(function (x) {
+  console.log(x);
+});
+
 function factorial(aux, n) {
   _letrec: while (true) {
     if (n === 0) {
       return aux;
     } else {
-      aux = aux * n;
-      n = n - 1;
+      var $tmp0 = aux * n;
+      var $tmp1 = n - 1;
+      aux = $tmp0;
+      n = $tmp1;
       continue _letrec;
     }
   }
@@ -29,8 +56,10 @@ function parseNum_parseTokens(_letrecFunction, tokens, acc, _arg1, _arg2) {
         var $target1 = function $target1() {
           return _arg2.tail == null ? _fableCore.List.reverse(tokens) : function () {
             _letrecFunction = "parseTokens";
-            tokens = tokens;
-            _arg2 = _arg2.tail;
+            var $tmp0 = tokens;
+            var $tmp1 = _arg2.tail;
+            tokens = $tmp0;
+            _arg2 = $tmp1;
           }();
         };
 
@@ -40,9 +69,14 @@ function parseNum_parseTokens(_letrecFunction, tokens, acc, _arg1, _arg2) {
             var xs = _arg2.tail;
             {
               _letrecFunction = "parseNum";
-              tokens = tokens;
-              acc = _fableCore.List.ofArray([x]);
-              _arg1 = xs;
+              var $tmp0 = tokens;
+
+              var $tmp1 = _fableCore.List.ofArray([x]);
+
+              var $tmp2 = xs;
+              tokens = $tmp0;
+              acc = $tmp1;
+              _arg1 = $tmp2;
               continue _letrec;
             }
           } else {
@@ -57,29 +91,40 @@ function parseNum_parseTokens(_letrecFunction, tokens, acc, _arg1, _arg2) {
     } else {
       if (_letrecFunction === "parseNum") {
         {
-          var $target1 = function $target1() {
+          var _$target = function _$target() {
             _letrecFunction = "parseTokens";
-            tokens = _fableCore.List.ofArray([_fableCore.List.reverse(acc)], tokens);
-            _arg2 = _arg1;
+
+            var $tmp0 = _fableCore.List.ofArray([_fableCore.List.reverse(acc)], tokens);
+
+            var $tmp1 = _arg1;
+            tokens = $tmp0;
+            _arg2 = $tmp1;
           };
 
           if (_arg1.tail != null) {
             if (_arg1.head >= "0" ? _arg1.head <= "9" : false) {
-              var x = _arg1.head;
-              var xs = _arg1.tail;
+              var _x = _arg1.head;
+              var _xs = _arg1.tail;
               {
                 _letrecFunction = "parseNum";
-                tokens = tokens;
-                acc = _fableCore.List.ofArray([x], acc);
-                _arg1 = xs;
+                var _$tmp = tokens;
+
+                var _$tmp2 = _fableCore.List.ofArray([_x], acc);
+
+                var _$tmp3 = _xs;
+                tokens = _$tmp;
+                acc = _$tmp2;
+                _arg1 = _$tmp3;
                 continue _letrec;
               }
             } else {
-              $target1();
+              _$target();
+
               continue _letrec;
             }
           } else {
-            $target1();
+            _$target();
+
             continue _letrec;
           }
         }


### PR DESCRIPTION
This is a dirty way of fixing some issues revealed when trying to compile the following code:

``` fsharp
let rec sum v m s =
    if v >= m
    then s
    else sum (v + 1L) m (s + v)
```
1. The plugin was failing in several places due to **empty lists**. I've tried to account for empty lists in those situation, but I'm not sure I'm taking the proper defaults.
2. Sometimes a variable is used for another arg when it has already been modified. For example, after fixing 1. the code above compiles to:

``` js
function sum(v, m, s) {
  _letrec: while (true) {
    if (v >= m) {
      return s;
    } else {
      v = v + 1;
      m = m;
      s = s + v;
      continue _letrec;
    }
  }
}
```

The problem is that, when assigning the new value of `s`, `v` has already changed so the result is different from the code run in F# interactive. I've temporarily fixed this by using temp variables:

``` js
function sum(v, m, s) {
  _letrec: while (true) {
    if (v >= m) {
      return s;
    } else {
      var $tmp0 = v + 1;
      var $tmp1 = m;
      var $tmp2 = s + v;
      v = $tmp0;
      m = $tmp1;
      s = $tmp2;
      continue _letrec;
    }
  }
}
```

As commented above, the solution is not very elegant. Please feel free to review and change it as you see fit.
